### PR TITLE
Fix: pd.Series() has append method which is deprecated

### DIFF
--- a/tti/indicators/_average_true_range.py
+++ b/tti/indicators/_average_true_range.py
@@ -83,10 +83,9 @@ class AverageTrueRange(TechnicalIndicator):
         atr['atr'] = atr[['TH-TL', 'YC-TH', 'YC-TL']].max(axis=1)
 
         # Wilder's Moving Average
-        atr['atr'] = pd.Series(
-            data=[atr['atr'].iloc[:14].mean()], index=[atr.index[13]]
-        ).append(atr['atr'].iloc[14:]).ewm(alpha=1 / 14,
-                                           adjust=False,).mean().round(4)
+        atr['atr'] = pd.concat([pd.Series(data=[atr['atr'].iloc[:14].mean()],
+                                           index=[atr.index[13]]), atr['atr'].iloc[14:]]).ewm(alpha=1/14,
+                                                                                              adjust=False).mean().round(4)
 
         return atr[['atr']]
 


### PR DESCRIPTION
pd.Series() has append method which is now [deprecated](https://pandas.pydata.org/pandas-docs/version/1.5/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append). I have fixed it with the concat method.
